### PR TITLE
Add Big Five personality control

### DIFF
--- a/crud/crud.py
+++ b/crud/crud.py
@@ -14,7 +14,12 @@ def create_character(db: Session, character: CharacterCreate) -> Character:
         tone=character.tone,
         world=character.world,
         prohibited=json.dumps(character.prohibited) if character.prohibited else None,
-        examples=json.dumps(character.examples) if character.examples else None
+        examples=json.dumps(character.examples) if character.examples else None,
+        openness=character.openness,
+        conscientiousness=character.conscientiousness,
+        extraversion=character.extraversion,
+        agreeableness=character.agreeableness,
+        neuroticism=character.neuroticism
     )
     db.add(db_character)
     db.commit()

--- a/main.py
+++ b/main.py
@@ -65,7 +65,18 @@ def build_full_prompt(character, trust_level: int) -> str:
     ) if character.examples else "なし"
     trust_text = get_prompt_by_level(trust_level)
 
-    return f"""あなたはこのキャラクターになりきってください。
+    return f"""あなたは「{character.name}」というキャラクターとして対話を行います。
+
+このキャラクターの性格は Big Five モデルに基づき、以下の通り数値で表されています。
+スコアは 0.0（非常に低い）〜 1.0（非常に高い）の範囲です。
+
+- Openness: {character.openness}
+- Conscientiousness: {character.conscientiousness}
+- Extraversion: {character.extraversion}
+- Agreeableness: {character.agreeableness}
+- Neuroticism: {character.neuroticism}
+
+これらの性格特性に基づき、発言内容・話し方・反応を自然に調整してください。
 
 【背景】
 {character.background}

--- a/models/models.py
+++ b/models/models.py
@@ -1,5 +1,5 @@
 import uuid
-from sqlalchemy import Column, String, Text, ForeignKey, DateTime, Integer
+from sqlalchemy import Column, String, Text, ForeignKey, DateTime, Integer, Float
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import func
 from sqlalchemy.dialects.postgresql import UUID  # PostgreSQL用UUID型
@@ -41,6 +41,13 @@ class Character(Base):
     # 対話例（ユーザーとキャラクターの例会話をJSONで保存）
     # 例: '[{"user": "こんにちは", "assistant": "やあ、よく来たね"}]'
     examples = Column(Text, nullable=True)
+
+    # Big Five スコア
+    openness = Column(Float, nullable=False, default=0.5)
+    conscientiousness = Column(Float, nullable=False, default=0.5)
+    extraversion = Column(Float, nullable=False, default=0.5)
+    agreeableness = Column(Float, nullable=False, default=0.5)
+    neuroticism = Column(Float, nullable=False, default=0.5)
 
 # 👤 ユーザー（プレイヤー）情報
 class User(Base):

--- a/schemas/schemas.py
+++ b/schemas/schemas.py
@@ -16,6 +16,13 @@ class CharacterCreate(BaseModel):
     prohibited: Optional[List[str]] = None    # 禁止事項（文字列のリスト）
     examples: Optional[List[Dict[str, str]]] = None  # 対話例（{"user": "...", "assistant": "..."} のリスト）
 
+    # Big Five スコア
+    openness: float = 0.5
+    conscientiousness: float = 0.5
+    extraversion: float = 0.5
+    agreeableness: float = 0.5
+    neuroticism: float = 0.5
+
 # 🔹 取得レスポンス用（キャラ情報表示）
 class CharacterResponse(BaseModel):
     id: UUID
@@ -29,6 +36,13 @@ class CharacterResponse(BaseModel):
     world: Optional[str] = None
     prohibited: Optional[List[str]] = None
     examples: Optional[List[Dict[str, str]]] = None
+
+    # Big Five スコア
+    openness: float
+    conscientiousness: float
+    extraversion: float
+    agreeableness: float
+    neuroticism: float
 
     class Config:
         from_attributes = True
@@ -44,6 +58,13 @@ class CharacterUpdate(BaseModel):
     world: Optional[str] = None
     prohibited: Optional[List[str]] = None
     examples: Optional[List[Dict[str, str]]] = None
+
+    # Big Five スコア（更新用）
+    openness: Optional[float] = None
+    conscientiousness: Optional[float] = None
+    extraversion: Optional[float] = None
+    agreeableness: Optional[float] = None
+    neuroticism: Optional[float] = None
 
 # 🔸 チャット送信用リクエスト（UUID指定）
 class ChatRequest(BaseModel):


### PR DESCRIPTION
## Summary
- extend `Character` DB model with Big Five personality scores
- expose these scores in create/update/response schemas
- store Big Five values when creating characters
- include scores in the system prompt so GPT can adjust character responses

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843b4593328832cb09aa2f5be4e2cbe