### PR TITLE
Implement full construct management

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ The API will be available on `http://localhost:8000` by default.
 | `POST /history/`                   | Store a chat message manually.             |
 | `GET /history/{user_id}/{character_id}` | Retrieve recent chat history.         |
 | `POST /evaluate-trust`             | Update trust score for a conversation.     |
+| `POST /constructs/`                | Create a value axis construct.  |
+| `GET /constructs/{user_id}/{character_id}` | List constructs for a user and character. |
+| `DELETE /constructs/{id}`          | Delete a construct by ID. |
+| `POST /constructs/import`          | Import constructs from JSONL. |
+| `GET /constructs/export/{user_id}/{character_id}` | Export constructs as JSONL. |
 
 See the `schemas` module for request and response shapes for each endpoint.
 

--- a/crud/crud.py
+++ b/crud/crud.py
@@ -39,7 +39,10 @@ def create_construct(db: Session, data: ConstructCreate) -> Construct:
     construct = Construct(
         user_id=data.user_id,
         character_id=data.character_id,
-        axis=data.axis,
+        axis=json.dumps(data.axis),
+        name=data.name,
+        importance=data.importance,
+        behavior_effect=data.behavior_effect,
         value=data.value,
     )
     db.add(construct)

--- a/models/models.py
+++ b/models/models.py
@@ -101,6 +101,7 @@ class InternalState(Base):
 # 🏷️ 価値軸（コンストラクト）
 class Construct(Base):
     """User specific value axis for a character."""
+
     __tablename__ = "constructs"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4, index=True)
@@ -111,8 +112,17 @@ class Construct(Base):
     # 関連キャラクター
     character_id = Column(UUID(as_uuid=True), ForeignKey("characters.id"), nullable=False)
 
-    # 軸名
-    axis = Column(String, nullable=False)
+    # 軸の両極値ペアをJSON文字列で保持
+    axis = Column(Text, nullable=False)
+
+    # 軸の名称
+    name = Column(String, nullable=False)
+
+    # 重要度（0〜5程度を想定）
+    importance = Column(Integer, default=0)
+
+    # 行動への影響説明
+    behavior_effect = Column(Text, nullable=False)
 
     # 値（-5～+5 程度を想定）
     value = Column(Integer, default=0)

--- a/schemas/schemas.py
+++ b/schemas/schemas.py
@@ -103,7 +103,10 @@ class EvaluateTrustRequest(BaseModel):
 class ConstructBase(BaseModel):
     user_id: UUID
     character_id: UUID
-    axis: str
+    axis: List[str]
+    name: str
+    importance: int = 0
+    behavior_effect: str
     value: int = 0
 
 


### PR DESCRIPTION
## Summary
- expand `Construct` model with name, importance, behavior effect and store axis as JSON
- extend Pydantic schemas for new construct fields
- update CRUD and API endpoints to handle new structure
- incorporate constructs in prompt formatting
- document new construct endpoints

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68450307ae54832caf8c54bd14299fb0