### PR TITLE
Add option to return OpenAI prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The API will be available on `http://localhost:8000` by default.
 | `PUT /characters/{name}`           | Update character details by name.          |
 | `GET /characters/`                 | List all characters.                       |
 | `DELETE /characters/{id}`          | Delete a character by ID.                  |
-| `POST /chat`                       | Send a message and receive a reply.        |
+| `POST /chat`                       | Send a message and receive a reply. Use `include_prompt=true` to also return the OpenAI prompt.        |
 | `POST /history/`                   | Store a chat message manually.             |
 | `GET /history/{user_id}/{character_id}` | Retrieve recent chat history.         |
 | `POST /evaluate-trust`             | Update trust score for a conversation.     |

--- a/main.py
+++ b/main.py
@@ -202,9 +202,12 @@ def chat(request: ChatRequest, db: Session = Depends(get_db)):
     ))
     db.commit()
 
+    response_data = {"reply": reply}
     if request.debug:
-        return {"reply": reply, "intent": intent}
-    return {"reply": reply}
+        response_data["intent"] = intent
+    if request.include_prompt:
+        response_data["prompt"] = [system_prompt] + messages
+    return response_data
 
 @app.post("/history/")
 def save_chat_message(chat: ChatMessage, db: Session = Depends(get_db)):

--- a/schemas/schemas.py
+++ b/schemas/schemas.py
@@ -72,6 +72,7 @@ class ChatRequest(BaseModel):
     character_id: UUID
     user_message: str
     debug: Optional[bool] = False
+    include_prompt: Optional[bool] = False
 
 # 🔸 会話履歴保存用リクエスト（UUID対応）
 class ChatMessage(BaseModel):


### PR DESCRIPTION
## Summary
- extend `ChatRequest` with `include_prompt` flag
- return full prompt from `/chat` when requested
- document the new parameter in the endpoint table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684513380ed8832c88597ef476453535