### PR TITLE
Support bulk construct creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The API will be available on `http://localhost:8000` by default.
 | `POST /history/`                   | Store a chat message manually.             |
 | `GET /history/{user_id}/{character_id}` | Retrieve recent chat history.         |
 | `POST /evaluate-trust`             | Update trust score for a conversation.     |
-| `POST /constructs/`                | Create a value axis construct.  |
+| `POST /constructs/`                | Create one or multiple value axis constructs. |
 | `GET /constructs/{user_id}/{character_id}` | List constructs for a user and character. |
 | `DELETE /constructs/{id}`          | Delete a construct by ID. |
 | `POST /constructs/import`          | Import constructs from JSONL. |

--- a/crud/crud.py
+++ b/crud/crud.py
@@ -51,6 +51,27 @@ def create_construct(db: Session, data: ConstructCreate) -> Construct:
     return construct
 
 
+# 🔸 複数コンストラクト作成
+def create_constructs(db: Session, constructs: List[ConstructCreate]) -> List[Construct]:
+    objs = []
+    for data in constructs:
+        obj = Construct(
+            user_id=data.user_id,
+            character_id=data.character_id,
+            axis=json.dumps(data.axis),
+            name=data.name,
+            importance=data.importance,
+            behavior_effect=data.behavior_effect,
+            value=data.value,
+        )
+        db.add(obj)
+        objs.append(obj)
+    db.commit()
+    for obj in objs:
+        db.refresh(obj)
+    return objs
+
+
 # 🔹 指定ユーザー・キャラのコンストラクト一覧
 def get_constructs(db: Session, user_id, character_id) -> List[Construct]:
     return (

--- a/main.py
+++ b/main.py
@@ -38,6 +38,7 @@ from crud.crud import (
     create_character,
     get_character_by_name,
     create_construct,
+    create_constructs,
     get_constructs,
     delete_construct,
 )
@@ -373,11 +374,12 @@ def evaluate_trust(data: EvaluateTrustRequest, db: Session = Depends(get_db)):
 
 # --------------------- Construct Endpoints ---------------------
 
-@app.post("/constructs/", response_model=ConstructResponse)
-def create_construct_route(data: ConstructCreate, db: Session = Depends(get_db)):
-    construct = create_construct(db, data)
-    construct.axis = data.axis
-    return construct
+@app.post("/constructs/", response_model=List[ConstructResponse])
+def create_construct_route(data: List[ConstructCreate], db: Session = Depends(get_db)):
+    constructs = create_constructs(db, data)
+    for obj, req in zip(constructs, data):
+        obj.axis = req.axis
+    return constructs
 
 
 @app.get("/constructs/{user_id}/{character_id}", response_model=List[ConstructResponse])


### PR DESCRIPTION
## Summary
- add `create_constructs` util in crud layer
- allow `/constructs/` endpoint to accept a list of constructs
- document bulk support for the endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684520e40610832c8ee6cce9c82297fe