### PR TITLE
Implement liking levels and endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The API will be available on `http://localhost:8000` by default.
 | `POST /chat`                       | Send a message and receive a reply. Use `include_prompt=true` to also return the OpenAI prompt.        |
 | `POST /history/`                   | Store a chat message manually.             |
 | `GET /history/{user_id}/{character_id}` | Retrieve recent chat history.         |
-| `POST /evaluate-trust`             | Update trust score for a conversation.     |
+| `POST /evaluate-liking`            | Update liking score for a conversation.    |
 | `POST /constructs/`                | Create one or multiple value axis constructs. |
 | `GET /constructs/{user_id}/{character_id}` | List constructs for a user and character. |
 | `DELETE /constructs/{id}`          | Delete a construct by ID. |

--- a/schemas/schemas.py
+++ b/schemas/schemas.py
@@ -100,6 +100,12 @@ class EvaluateTrustRequest(BaseModel):
     character_id: UUID
     player_message: str
 
+# 👍 好意度評価用リクエスト
+class EvaluateLikingRequest(BaseModel):
+    user_id: UUID
+    character_id: UUID
+    player_message: str
+
 # ✅ コンストラクト関連
 class ConstructBase(BaseModel):
     user_id: UUID


### PR DESCRIPTION
## Summary
- add `EvaluateLikingRequest` schema
- update prompt builder to use liking levels
- add helper for mapping liking score to level
- migrate `/chat` and `/evaluate-liking` endpoints to new liking logic
- document the new endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846587bb640832c9dbc809e19852d36