### PR TITLE
Rename EvaluateTrustRequest

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ from schemas.schemas import (
     ChatHistoryResponse,
     ChatRequest,
     UserCreate,
-    EvaluateTrustRequest,
+    EvaluateLikingRequest,
     ConstructCreate,
     ConstructResponse,
 )
@@ -303,7 +303,7 @@ def create_user(user: UserCreate, db: Session = Depends(get_db)):
     return {"id": new_user.id, "username": new_user.username}
 
 @app.post("/evaluate-trust")
-def evaluate_trust(data: EvaluateTrustRequest, db: Session = Depends(get_db)):
+def evaluate_trust(data: EvaluateLikingRequest, db: Session = Depends(get_db)):
     system_prompt = """
     あなたはゲームキャラクターとして、プレイヤーの発言に対する信頼度を評価する役割を担っています。
     以下のスケールに基づき、信頼度を評価し、出力形式に厳密に従ってください。

--- a/schemas/schemas.py
+++ b/schemas/schemas.py
@@ -95,7 +95,7 @@ class UserCreate(BaseModel):
     username: str
 
 # ✅ 信頼度評価用リクエスト
-class EvaluateTrustRequest(BaseModel):
+class EvaluateLikingRequest(BaseModel):
     user_id: UUID
     character_id: UUID
     player_message: str


### PR DESCRIPTION
## Summary
- rename `EvaluateTrustRequest` dataclass to `EvaluateLikingRequest`
- update imports in `main.py`
- adapt `/evaluate-trust` endpoint to use the renamed request model

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6846587fda00832ca1472970e9299c4d