### PR TITLE
Add ApiConfig and reference base URL across client scripts

### DIFF
--- a/unity-client/Assets/Scripts/ApiConfig.cs
+++ b/unity-client/Assets/Scripts/ApiConfig.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+public static class ApiConfig
+{
+    // Base URL for all API requests
+    public const string BaseUrl = "https://my-chat-app-1-3wr3.onrender.com";
+}

--- a/unity-client/Assets/Scripts/CharacterClick.cs
+++ b/unity-client/Assets/Scripts/CharacterClick.cs
@@ -14,7 +14,7 @@ public class CharacterClick : MonoBehaviour
 
     IEnumerator FetchCharacterNameFromList()
     {
-        string url = "https://my-chat-app-1-3wr3.onrender.com/characters/";
+        string url = ApiConfig.BaseUrl + "/characters/";
 
         using (UnityWebRequest request = UnityWebRequest.Get(url))
         {

--- a/unity-client/Assets/Scripts/ChatHistoryLoader.cs
+++ b/unity-client/Assets/Scripts/ChatHistoryLoader.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 public class ChatHistoryLoader : MonoBehaviour
 {
     [Header("API設定")]
-    public string historyUrl = "https://my-chat-app-1-3wr3.onrender.com/history/{0}/{1}";
+    public string historyUrl = ApiConfig.BaseUrl + "/history/{0}/{1}";
     public string userId = "1f494426-588c-4a74-a5a0-6d9d1dafebec";
     public string characterId = "854d5e61-9d5c-45c6-b3b6-019acfba777e";
 

--- a/unity-client/Assets/Scripts/ChatManager.cs
+++ b/unity-client/Assets/Scripts/ChatManager.cs
@@ -11,7 +11,7 @@ public class ChatManager : MonoBehaviour
     public Text trustText;            // 信頼度スコア表示欄（パネル上に配置）
 
     [Header("API設定")]
-    public string apiUrl = "https://my-chat-app-1-3wr3.onrender.com/chat";
+    public string apiUrl = ApiConfig.BaseUrl + "/chat";
 
     [Header("ID設定（UUID形式）")]
     public string userId = "1f494426-588c-4a74-a5a0-6d9d1dafebec";

--- a/unity-client/Assets/Scripts/TrustEvaluator.cs
+++ b/unity-client/Assets/Scripts/TrustEvaluator.cs
@@ -9,7 +9,7 @@ public class TrustEvaluator : MonoBehaviour
     public InputField inputField;  // ユーザー入力欄（ChatManagerのInputFieldをアサイン）
 
     [Header("API設定")]
-    public string evaluateTrustUrl = "https://my-chat-app-1-3wr3.onrender.com/evaluate-trust";
+    public string evaluateTrustUrl = ApiConfig.BaseUrl + "/evaluate-trust";
 
     [Header("ID設定（UUID形式）")]
     public string userId = "1f494426-588c-4a74-a5a0-6d9d1dafebec";


### PR DESCRIPTION
## Summary
- introduce `ApiConfig.cs` defining `BaseUrl`
- update `ChatManager`, `ChatHistoryLoader`, `TrustEvaluator` and `CharacterClick` to build API URLs using `ApiConfig.BaseUrl`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684840e01e08832c965547b3172c4063