### PR TITLE
Update trust evaluator endpoint

### DIFF
--- a/unity-client/Assets/Scripts/TrustEvaluator.cs
+++ b/unity-client/Assets/Scripts/TrustEvaluator.cs
@@ -9,7 +9,8 @@ public class TrustEvaluator : MonoBehaviour
     public InputField inputField;  // ユーザー入力欄（ChatManagerのInputFieldをアサイン）
 
     [Header("API設定")]
-    public string evaluateTrustUrl = ApiConfig.BaseUrl + "/evaluate-trust";
+    // 信頼度ではなく好感度を評価する "evaluate-liking" エンドポイント
+    public string evaluateTrustUrl = ApiConfig.BaseUrl + "/evaluate-liking";
 
     [Header("ID設定（UUID形式）")]
     public string userId = "1f494426-588c-4a74-a5a0-6d9d1dafebec";


### PR DESCRIPTION
## Summary
- update `evaluateTrustUrl` to call `/evaluate-liking`
- clarify the comment for the new `evaluate-liking` endpoint

## Testing
- `python -m backend.create_tables` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848430d5910832cac488ef95c8135d6