### PR TITLE
Use typed payloads for API requests

### DIFF
--- a/unity-client/Assets/Scripts/ChatManager.cs
+++ b/unity-client/Assets/Scripts/ChatManager.cs
@@ -22,6 +22,14 @@ public class ChatManager : MonoBehaviour
 
     private int currentTrust = 0;
 
+    [System.Serializable]
+    private class ChatRequestPayload
+    {
+        public string user_id;
+        public string character_id;
+        public string user_message;
+    }
+
     void Start()
     {
         UpdateTrustDisplay(); // 起動時に初期表示
@@ -40,7 +48,14 @@ public class ChatManager : MonoBehaviour
     // GPTに送信する処理（POST）
     IEnumerator SendMessageToAPI(string message)
     {
-        string jsonData = $"{{\"user_id\":\"{userId}\",\"character_id\":\"{characterId}\",\"user_message\":\"{message}\"}}";
+        var payload = new ChatRequestPayload
+        {
+            user_id = userId,
+            character_id = characterId,
+            user_message = message
+        };
+
+        string jsonData = JsonUtility.ToJson(payload);
 
         Debug.Log("📤 Chat送信JSON: " + jsonData);
 

--- a/unity-client/Assets/Scripts/TrustEvaluator.cs
+++ b/unity-client/Assets/Scripts/TrustEvaluator.cs
@@ -19,6 +19,14 @@ public class TrustEvaluator : MonoBehaviour
     [Header("連携スクリプト")]
     public ChatManager chatManager;  // ← Unityでアサイン
 
+    [System.Serializable]
+    private class EvaluateTrustPayload
+    {
+        public string user_id;
+        public string character_id;
+        public string player_message;
+    }
+
     /// <summary>
     /// ユーザーが入力欄に書いた内容を評価（ボタン連携用）
     /// </summary>
@@ -54,7 +62,14 @@ public class TrustEvaluator : MonoBehaviour
     /// </summary>
     IEnumerator PostEvaluateTrust(string userMessage)
     {
-        string json = $"{{\"user_id\":\"{userId}\",\"character_id\":\"{characterId}\",\"player_message\":\"{userMessage}\"}}";
+        var payload = new EvaluateTrustPayload
+        {
+            user_id = userId,
+            character_id = characterId,
+            player_message = userMessage
+        };
+
+        string json = JsonUtility.ToJson(payload);
 
         Debug.Log("📤 送信するJSON: " + json);
 


### PR DESCRIPTION
## Summary
- add `ChatRequestPayload` nested class in `ChatManager`
- add `EvaluateTrustPayload` nested class in `TrustEvaluator`
- build JSON bodies with `JsonUtility.ToJson`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684844dc4754832c94b256e679ed6e80