### PR TITLE
Update Unity ApiConfig with local default

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ The API will be available at `http://localhost:8000` by default.
 ## Unity client
 
 Open the `unity-client/` folder with Unity Hub or the Unity editor. The C# scripts
-are stored in `Assets/Scripts/`. If you need to use a different API endpoint,
-edit the URL value in the networking script (for example `ChatManager.cs`).
+are stored in `Assets/Scripts/`.
+
+The API base URL is controlled by `ApiConfig.cs`. By default it uses
+`http://localhost:8000`, but you can override this by setting the PlayerPrefs
+key `API_BASE_URL` (or an environment variable of the same name) before
+running the client.
 
 Build or run the scene from the editor to debug the client.
 

--- a/unity-client/Assets/Scripts/ApiConfig.cs
+++ b/unity-client/Assets/Scripts/ApiConfig.cs
@@ -2,6 +2,33 @@ using UnityEngine;
 
 public static class ApiConfig
 {
+    // Key name used for PlayerPrefs or environment variable
+    private const string ConfigKey = "API_BASE_URL";
+
+    // Default URL when no configuration is provided
+    private const string DefaultUrl = "http://localhost:8000";
+
     // Base URL for all API requests
-    public const string BaseUrl = "https://my-chat-app-1-3wr3.onrender.com";
+    public static string BaseUrl
+    {
+        get
+        {
+            // Check Unity's PlayerPrefs first
+            string prefUrl = PlayerPrefs.GetString(ConfigKey);
+            if (!string.IsNullOrEmpty(prefUrl))
+            {
+                return prefUrl;
+            }
+
+            // Fallback to environment variable
+            string envUrl = System.Environment.GetEnvironmentVariable(ConfigKey);
+            if (!string.IsNullOrEmpty(envUrl))
+            {
+                return envUrl;
+            }
+
+            // Default local development URL
+            return DefaultUrl;
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- let Unity client read API base URL from PlayerPrefs or env var
- default to `http://localhost:8000`
- document overriding the base URL in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484580b274832c94fab85e1d7a1766