### PR TITLE
Load env file in table creation script

### DIFF
--- a/backend/create_tables.py
+++ b/backend/create_tables.py
@@ -1,3 +1,9 @@
+from dotenv import load_dotenv
+from pathlib import Path
+
+env_path = Path('.') / '.env'
+load_dotenv(dotenv_path=env_path)
+
 from backend.db.database import engine
 from backend.models.models import Base
 


### PR DESCRIPTION
## Summary
- ensure the `.env` file is loaded before creating tables

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement annotated-types==0.7.0)*
- `python -m backend.create_tables` *(fails: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_68484a7e6770832c998705bbfe957315