### PR TITLE
Fix PlayerPrefs usage in Unity scripts

### DIFF
--- a/unity-client/Assets/Scripts/ChatHistoryLoader.cs
+++ b/unity-client/Assets/Scripts/ChatHistoryLoader.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 public class ChatHistoryLoader : MonoBehaviour
 {
     [Header("API設定")]
-    public string historyUrl = ApiConfig.BaseUrl + "/history/{0}/{1}";
+    public string historyUrl;
     public string userId = "1f494426-588c-4a74-a5a0-6d9d1dafebec";
     public string characterId = "854d5e61-9d5c-45c6-b3b6-019acfba777e";
 
@@ -30,6 +30,11 @@ public class ChatHistoryLoader : MonoBehaviour
     public class ChatEntryListWrapper
     {
         public ChatEntry[] history;
+    }
+
+    void Awake()
+    {
+        historyUrl = ApiConfig.BaseUrl + "/history/{0}/{1}";
     }
 
     void Start()

--- a/unity-client/Assets/Scripts/ChatManager.cs
+++ b/unity-client/Assets/Scripts/ChatManager.cs
@@ -11,7 +11,7 @@ public class ChatManager : MonoBehaviour
     public Text trustText;            // 信頼度スコア表示欄（パネル上に配置）
 
     [Header("API設定")]
-    public string apiUrl = ApiConfig.BaseUrl + "/chat";
+    public string apiUrl;
 
     [Header("ID設定（UUID形式）")]
     public string userId = "1f494426-588c-4a74-a5a0-6d9d1dafebec";
@@ -28,6 +28,11 @@ public class ChatManager : MonoBehaviour
         public string user_id;
         public string character_id;
         public string user_message;
+    }
+
+    void Awake()
+    {
+        apiUrl = ApiConfig.BaseUrl + "/chat";
     }
 
     void Start()

--- a/unity-client/Assets/Scripts/TrustEvaluator.cs
+++ b/unity-client/Assets/Scripts/TrustEvaluator.cs
@@ -10,7 +10,7 @@ public class TrustEvaluator : MonoBehaviour
 
     [Header("API設定")]
     // 信頼度ではなく好感度を評価する "evaluate-liking" エンドポイント
-    public string evaluateTrustUrl = ApiConfig.BaseUrl + "/evaluate-liking";
+    public string evaluateTrustUrl;
 
     [Header("ID設定（UUID形式）")]
     public string userId = "1f494426-588c-4a74-a5a0-6d9d1dafebec";
@@ -18,6 +18,11 @@ public class TrustEvaluator : MonoBehaviour
 
     [Header("連携スクリプト")]
     public ChatManager chatManager;  // ← Unityでアサイン
+
+    void Awake()
+    {
+        evaluateTrustUrl = ApiConfig.BaseUrl + "/evaluate-liking";
+    }
 
     [System.Serializable]
     private class EvaluateTrustPayload


### PR DESCRIPTION
## Summary
- avoid calling `ApiConfig.BaseUrl` in field initializers
- initialize URLs in `Awake()` for `ChatManager`, `ChatHistoryLoader` and `TrustEvaluator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68491a44be0c832cbac53cbcd01ad0f0