### PR TITLE
Enhance error logging in ChatManager

### DIFF
--- a/unity-client/Assets/Scripts/ChatManager.cs
+++ b/unity-client/Assets/Scripts/ChatManager.cs
@@ -90,8 +90,9 @@ public class ChatManager : MonoBehaviour
             }
             else
             {
-                responseText.text = $"エラー: HTTP/{request.responseCode}";
-                Debug.LogError("❌ Chat送信失敗: " + request.error);
+                string serverMessage = request.downloadHandler.text;
+                responseText.text = $"エラー: HTTP/{request.responseCode}\n{serverMessage}";
+                Debug.LogError($"❌ Chat送信失敗: {request.error}\n{serverMessage}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- append API error details from `downloadHandler` in `SendMessageToAPI`
- show the server's message in the UI for easier debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494126f45c832c8ba30703bbb52691